### PR TITLE
cloudyr onboarding

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@ man-roxygen
 CONTRIBUTING\.md
 ^_ignore$
 \.sublime\-
+^drat.sh$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: r
+sudo: required
+r_packages:
+- knitr
+- covr
+- drat
+after_success:
+- Rscript -e 'library("covr");codecov()'
+- test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && bash
+  drat.sh
+env:
+  global:
+    secure: Gny6RyfFspY/nyiUKFFNQ4VqCDMK7dEZAALnl6WOjqMLfuHoXIjiFx8/yEAhfdbw5m/pUnQmaBney7Y/3O6DcpCvamnig6oSpljxSKMjYRU/6s/W7fqmTNm556oeV8bGVzSxFRr9hVtCXLxTpGHCKNWwxVgzzXNqUxodui9WEPnaSkqBESBA+c3VphAG8nhRorQszlGwgNxjswJwWj0631zvKU5gLRzWEwSK2ApN0Dom/Rg5z+9u7iu2peg4FO1jfnre1U6rDRqoIxS3RupfMY7BpITszxsJ3DkFFauQNHBUoULU2HFVnXFEDHmDU76yYXbZ5y7T/KZWbcQp949fNnoC6MBoqe18FLeQQtETE8Xu2zL4NgiLddbK6CqaSljW7HycNpdL7nYymNaAsil7i/P/sRSkKuDzPSCMz/dTE0YljHDhBQ3cIyNzmblKzOaMffY/hSeWqsk6BjdUB9JWfWlhrwEkR7KtnQL2hCMHg+eNGGXq1yJB+2kL1V8jHvIt7WuxQrYuvmxD3LjLEdkPJhdGU+BoaKTcs12G1SnUph5rf34+8WYNHmu5MiWVk+FzuyFJboEhB8JzEUyclCr7Fi7IsNhTpPRSWpLg2SHsQk7AjJEesd4tbdd1eb+ivHVlc25cLK3YG2Nagyvch6f59f6wYIHNLxeCHr/Vjm3RDS4=

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,6 +5,8 @@ Authors@R: person("Ryan", "Hafen", email = "rhafen@gmail.com", role = c("aut", "
 Description: Serve graphics (lattice/ggplot, htmlwidgets, help) over http from
     an interactive R session running through ssh on a remote server.
 License: MIT + file LICENSE
+URL: https://github.com/cloudyr/rmote
+BugReports: https://github.com/cloudyr/rmote/issues
 LazyData: true
 Depends:
     R (>= 3.1)

--- a/README.md
+++ b/README.md
@@ -87,3 +87,29 @@ If you must work on a remote terminal, here are some additional utilities that h
 - [Sublime](https://www.sublimetext.com) + [SFTP](http://wbond.net/sublime_packages/sftp)
 - [Vim](http://www.vim.org) + [Vim-R-plugin](https://github.com/vim-scripts/Vim-R-plugin)
 
+
+## Installation ##
+
+[![CRAN](http://www.r-pkg.org/badges/version/rmote)](http://cran.r-project.org/package=rmote)
+[![Build Status](https://travis-ci.org/cloudyr/rmote.png?branch=master)](https://travis-ci.org/cloudyr/rmote)
+[![codecov.io](http://codecov.io/github/cloudyr/rmote/coverage.svg?branch=master)](http://codecov.io/github/cloudyr/rmote?branch=master)
+
+This package is not yet on CRAN. To install the latest development version you can install from the cloudyr drat repository:
+
+```R
+# latest stable version
+install.packages("rmote", repos = c(getOption("repos"), "http://cloudyr.github.io/drat"))
+```
+
+Or, to pull a potentially unstable version directly from GitHub:
+
+```R
+if(!require("ghit")){
+    install.packages("ghit")
+}
+ghit::install_github("cloudyr/rmote")
+```
+
+
+---
+[![cloudyr project logo](http://i.imgur.com/JHS98Y7.png)](https://github.com/cloudyr)

--- a/drat.sh
+++ b/drat.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -o errexit -o nounset
+addToDrat(){
+  mkdir drat; cd drat
+
+  ## Set up Repo parameters
+  git init
+  git config user.name "leeper"
+  git config user.email "thosjleeper@gmail.com"
+  git config --global push.default simple
+
+  ## Get drat repo
+  git remote add upstream "https://$GH_TOKEN@github.com/cloudyr/cloudyr.github.io.git"
+  git fetch upstream
+  git checkout master
+
+  Rscript -e "drat::insertPackage('../$PKG_TARBALL', repodir = './drat')"
+  git add --all
+  git commit -m "add $PKG_TARBALL (build $TRAVIS_BUILD_ID)"
+  git push
+
+}
+addToDrat


### PR DESCRIPTION
This is just an "onboarding" edit that add some branding and installation instructions to the README, adds URLs to DESCRIPTION, and configures the package for travis-ci continuous integration, code coverage, and distribution via the cloudyr drat.