### PR TITLE
Please check if this makes snese

### DIFF
--- a/R/basegraphics.R
+++ b/R/basegraphics.R
@@ -37,6 +37,6 @@ set_base_plot_hook <- function() {
 }
 
 unset_base_plot_hook <- function() {
-  setHook("before.plot.new", getOption("pre_plot_hook"), "replace")
+  setHook("before.plot.new", getOption("prev_plot_hook"), "replace")
 }
 

--- a/R/basegraphics.R
+++ b/R/basegraphics.R
@@ -9,7 +9,8 @@ plot_done <- function() {
 make_base_plot <- function() {
   rmb <- getOption("rmote_baseplot")
   if(!is.null(rmb)) {
-    dev.off()
+    if(dev.cur() > 1)
+      dev.off()
     res <- write_html(rmb$html)
     options(rmote_baseplot = NULL)
     if(is_history_on())

--- a/R/rmote.R
+++ b/R/rmote.R
@@ -27,6 +27,8 @@ start_rmote <- function(
   if(!file.exists(server_dir))
     dir.create(server_dir, recursive = TRUE, showWarnings = FALSE)
 
+  options(rmote_on = TRUE)
+
   options(rmote_server_dir = server_dir)
   options(rmote_server_port = port)
   options(rmote_help = help)


### PR DESCRIPTION
- avoid error when no device open except the default `NULL` device.
- turn on rmote when `start_rmote()` is called.